### PR TITLE
Add api base.

### DIFF
--- a/api/answear.ts
+++ b/api/answear.ts
@@ -1,0 +1,22 @@
+import * as client from './client'
+
+export type AnswearRequest = {
+  html: string
+  css: string
+  javascript: string
+}
+
+export type AnswearResponse = {
+  url: string
+  imgScore: number
+}
+
+export const createAnswear = async (
+  ans: AnswearRequest
+): Promise<AnswearResponse> => {
+  const res = await client.post<AnswearRequest, AnswearResponse>(
+    '/answear',
+    ans
+  )
+  return res
+}

--- a/api/client.ts
+++ b/api/client.ts
@@ -1,0 +1,27 @@
+type EmptyObject = Record<string, never>
+/* TODO */
+const PATH_PREFIX = `https://xxxxxxxxxxx/api`
+
+export async function get<Response = EmptyObject>(
+  path: string
+): Promise<Response> {
+  const url = new URL(PATH_PREFIX + path)
+  const res = await fetch(url.toString(), {
+    method: 'GET',
+  })
+  return await res.json()
+}
+
+export async function post<Body = EmptyObject, Response = EmptyObject>(
+  path: string,
+  body: Body = {} as Body
+): Promise<Response> {
+  const res = await fetch(PATH_PREFIX + path, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(body),
+  })
+  return await res.json()
+}

--- a/api/problem.ts
+++ b/api/problem.ts
@@ -1,0 +1,18 @@
+import * as client from './client'
+
+/**
+ * wip api.
+ */
+
+type Problem = {
+  id: number
+  image: string[]
+  source_code: string
+  created_at: Date
+  updated_at: Date
+}
+
+export const getProblem = async (req: {}): Promise<Problem> => {
+  const res = await client.get<Problem>('/problem')
+  return res
+}

--- a/component/aceComponent/ace.tsx
+++ b/component/aceComponent/ace.tsx
@@ -7,6 +7,7 @@ import ReactAce, {
   keyBind,
   KeyBind,
 } from './aceInternal'
+import { createAnswear } from '../../api/answear'
 
 type EditorText = { [P in LanguageMode]: string }
 
@@ -43,7 +44,8 @@ const AceComponent: React.FC = () => {
   }
 
   const onSend = () => {
-    // TODO: Serverへのrequest処理
+    // TODO: 確認msg的なものを入れたい.
+    createAnswear(editorText)
   }
 
   return (


### PR DESCRIPTION
#15 
cc @HosokawaR 

* client apiのベース的なもの.
* とりあえず現在わかっている`answear`と`problem`の分.
* リクエスト先URLはまだdummyのハードコードだけど、エンドポイント決まればリクエストはできそう.